### PR TITLE
Update spec to support protocol handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ___
 
 ### Stratis ID
 
-A Stratis ID can be broken down into the following parts:
+A Stratis ID consists of the following parts:
 
 - The callback - a protocol-relative URL to which the wallet will send a HTTPS request
 - The UID - a unique identifier for a request, which is present within the query string of the callback

--- a/README.md
+++ b/README.md
@@ -22,25 +22,38 @@ ___
 
 ## Implementation
 
-### Stratis ID URI
+### Stratis ID
 
-A Stratis ID URI consists of three required parts, as well as optional parts:
+A Stratis ID can be broken down into the following parts:
 
-- The scheme - `sid`
-- The callback - a protocol-relative URL which the wallet will send a HTTPS request
+- The callback - a protocol-relative URL to which the wallet will send a HTTPS request
 - The UID - a unique identifier for a request, which is present within the query string of the callback
 - The expiry datetime (optional) - a unix timestamp that specifies when the signature should expire, which is present within the query string of the callback
 
-**Example:** `sid:api.example.com/auth?uid=4606287adc774829ab643816a021efbf&exp=1647216000`
+**Example:** `api.example.com/auth?uid=4606287adc774829ab643816a021efbf&exp=1647216000`
+
+#### Handling the Stratis ID URI
+
+You can handle the Stratis ID in two ways:
+
+1. As a URI, using the scheme _sid:_
+    ```
+    sid:api.example.com/auth?uid=4606287adc774829ab643816a021efbf&exp=1647216000
+    ```
+2. With a protocol handler URI, using the scheme _web+sid:_
+    ```
+    web+sid:api.example.com/auth?uid=4606287adc774829ab643816a021efbf&exp=1647216000
+    ```
 
 ### Wallet Compatibility
 
 Wallet compatibility relies on the implementation of the following requirements:
 
-- Ability to scan QR code or retrieve Stratis ID URI
+- Ability to scan QR code or input Stratis ID URI
+- The wallet is registered to be able to handle the _web+sid:_ protocol
 - User or wallet _must_ validate the callback url of the authentication request
 - Wallet _should_ verify that the expiry datetime has not passed, if it is present
-- Sign the callback present in the Stratis ID URI
+- Sign the full Stratis ID callback
     ```
     message.Sign("api.example.com/auth?uid=4606287adc774829ab643816a021efbf&exp=1647216000")
     ```
@@ -58,7 +71,8 @@ Wallet compatibility relies on the implementation of the following requirements:
 
 dApp compatibility relies on the implementation of the following requirements:
 
-- Generate a QR code containing a Stratis ID URI and display this to the user
+- Generate and display a QR code containing a Stratis ID URI to the user
+- Include a button link for the protocol handler URL
 - Host a HTTPS endpoint that is used in the Stratis ID URI callback
   - The endpoint _must_ validate the structure and contents of the request body
   - The endpoint _must_ verify the signature and its contents


### PR DESCRIPTION
Supports [protocol handlers](https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/972.html#protocol_handlers-member), so that users can click a button link on a dApp to open their wallet which will authenticate them.

![image](https://user-images.githubusercontent.com/39023939/154288875-ac141bce-800f-4e59-9b3f-b0689e428043.png)

I've added what I believe to be the bare minimum required to support protocol handlers. Some additional discussion points:

* Should the spec include CSS styling for the button link? This may make it more familiar to users, as they would see the same _Login with Stratis ID_ or _Open Wallet_ button across dApps.
* How do dApps handle the case where no protocol handlers are registered? Potentially the spec should include this information.